### PR TITLE
oauth2: fixed revoke token broken test

### DIFF
--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -31,4 +31,4 @@ class HydraTestCase(unittest.TestCase):
 
         self.assertTrue(response)
         instrospection = self.hydra.instrospect_token(token)
-        self.assertIsNone(instrospection)
+        self.assertFalse(instrospection['active'])


### PR DESCRIPTION
Due to a hydra protocol update, HydraTestCase.test_can_revoke_token
was broken. hydra.instrospect_token used to return null with a
inactive token and now it returns an object indicating that the token
is not active anymore. The broken test were updated to this new
protocol.

Signed-off-by: Pablo Palácios <ppalacios992@gmail.com>