### PR TITLE
Replace pycrypto with pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version='0.9.0',
     packages=['hydra'],
     install_requires=[
-        'pycrypto==2.6.1',
+        'pycryptodome==3.6.4',
         'python-jose==1.3.2',
         'requests==2.18.1',
     ],


### PR DESCRIPTION
PyCrypto is dead upstream and is affected by CVE-2018-6594 flaw. We
are now replacing it with pycryptodome which is well maintained and do
not suffer of same issue.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>