### PR TITLE
Travis CI: update Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: python
 
 python:
-  - 3.5
   - 3.6
 
 services:


### PR DESCRIPTION
This update the test matrix to check Python 3.6 and 3.7 versions.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>